### PR TITLE
Modify search.json to not require posts

### DIFF
--- a/jekyll/search.json
+++ b/jekyll/search.json
@@ -13,20 +13,9 @@ search: exclude
 "keywords": "{{page.keywords}}",
 "url": "{{ page.url | remove: "/"}}",
 "summary": "{{page.summary | strip }}"
-},
-{% endunless %}
-{% endfor %}
-
-{% for post in site.posts %}
-
-{
-"title": "{{ post.title | escape }}",
-"tags": "{{ post.tags }}",
-"keywords": "{{post.keywords}}",
-"url": "{{ post.url }}",
-"summary": "{{post.summary | strip }}"
 }
 {% unless forloop.last %},{% endunless %}
+{% endunless %}
 {% endfor %}
 
 ]


### PR DESCRIPTION
By simply removing the 'posts' section from search.json, and adding an end to the loop for the insertion of the comma, the basic jekyll search now works.
