### PR TITLE
Add steps for testing and installing Jekyll

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ confluence-export/raw-xml-export
 confluence-export/page-tree.xml
 html/scripts/*
 .DS_Store
+.ant_targets
+Gemfile.lock

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,10 @@
+source 'https://rubygems.org'
+
+gem 'jekyll'
+
+gem 'pygments.rb'
+gem 'yajl-ruby'
+
+group :jekyll_plugins do
+  gem 'jekyll-asciidoc'
+end

--- a/README.adoc
+++ b/README.adoc
@@ -23,10 +23,19 @@ This repo includes HTML pages already generated for casual review. A demo is als
 
 However, this project includes `ant` targets for building HTML and PDF versions of the Ref Guide. The idea is that these could eventually be integrated with Solr's build tasks to automatically generate the Solr Ref Guide.
 
-* `ant asciidoctor` builds the HTML files by finding all `.adoc` files from `asciidoc` directory and making an HTML file for each page. It downloads the https://github.com/asciidoctor/asciidoctor-ant[asciidoctor-ant] .jar file as a dependency.
-* `ant jbake-site` builds a full HTML site using JBake, a static site generator. This provides templatized HTML files. `ant jbake-clean` removes previously built files. This requires (at the moment) that http://www.jbake.org/[JBake] is installed where the build will occur.
-* `ant jekyll-site` builds a full HTML site using Jekyll, another static site generator. `ant jekyll-clean` removes previously built files. This requires (at the moment) that https://jekyllrb.com/[Jekyll] is installed where the build is happening.
-* `ant pdf2` builds a PDF from the files defined in `jekylltest/SolrRefGuide.adoc`. This uses the same `asciidoctor-ant` jar used with the `asciidoctor` target and will be downloaded to the build machine when necessary.
+* `ant build` builds the HTML and PDF versions of the site
+* `ant build-jekyll` builds the HTML version of the site
+* `ant build-pdf` builds the PDF version of the site
+
+The above assume that `jekyll` is already installed. If it is not installed, perform the following:
+
+* Make sure that Ruby is installed.
+* `gem install bundler`
+* `bundle install`
+
+Testing the site can be done with the following after building:
+
+* `jekyll serve --source build/jekyll --destination build/jekyll/_site --incremental --watch`
 
 == Conversion Tools
 


### PR DESCRIPTION
Added a Gemfile for making sure that Jekyll is installed and using Jekyll to serve the guide for testing the search box (otherwise fails w/ cross domain error).

If this isn't useful no worries just made it easier for me to proofread the latest changes.
